### PR TITLE
fix run_tests for wasm

### DIFF
--- a/scripts/run_tests
+++ b/scripts/run_tests
@@ -27,7 +27,7 @@ fi
 if [ -z "$WASM_MODE" ]; then
   TEST_CMD="./bin/\$BIN $@"
 else
-  TEST_CMD="wasmtime --dir .. bin/\$BIN $@"
+  TEST_CMD="~/.wasmtime/bin/wasmtime --dir .. bin/\$BIN $@"
 fi
 
 docker run --rm -t $IMAGE_URI /bin/sh -c "\

--- a/scripts/run_tests
+++ b/scripts/run_tests
@@ -3,10 +3,11 @@ set -e
 
 NUM_TRANSCRIPTS=$1
 TESTS=$2
+WASM_MODE=$3
 shift
 shift
-if [ -n "$3" ]; then
-  WASM_MODE=$3
+
+if [ -n "$WASM_MODE" ]; then
   shift
 fi
 

--- a/scripts/run_tests
+++ b/scripts/run_tests
@@ -9,11 +9,14 @@ shift
 
 if [ -n "$WASM_MODE" ]; then
   shift
+  ARCH=wasm
+else
+  ARCH=x86_64
 fi
 
 $(aws ecr get-login --region us-east-2 --no-include-email) 2> /dev/null
 
-IMAGE_URI=278380418400.dkr.ecr.us-east-2.amazonaws.com/aztec3-circuits-x86_64-linux-clang-assert:cache-$COMMIT_HASH
+IMAGE_URI=278380418400.dkr.ecr.us-east-2.amazonaws.com/aztec3-circuits-$ARCH-linux-clang-assert:cache-$COMMIT_HASH
 
 docker pull $IMAGE_URI
 


### PR DESCRIPTION
* `WASM_MODE` argument (`$3`) needs to be captured before call to `shift`, and it can be checked for empty afterwards.
* Need to make sure we are pulling from `wasm` vs `x86_64` based on mode
* Need to use full path to `wasmtime` when running it inside `/bin/sh`