### PR TITLE
Linearised Prover Removed from BB

### DIFF
--- a/src/aztec3/circuits/kernel/private/.test.cpp
+++ b/src/aztec3/circuits/kernel/private/.test.cpp
@@ -118,7 +118,7 @@ TEST(private_kernel_tests, test_deposit)
     OptionalPrivateCircuitPublicInputs<NT> opt_deposit_public_inputs = deposit(deposit_ctx, amount, asset_id, memo);
     PrivateCircuitPublicInputs<NT> deposit_public_inputs = opt_deposit_public_inputs.remove_optionality();
 
-    UnrolledProver deposit_prover = deposit_composer.create_unrolled_prover();
+    Prover deposit_prover = deposit_composer.create_prover();
     NT::Proof deposit_proof = deposit_prover.construct_proof();
     // info("\ndeposit_proof: ", deposit_proof.proof_data);
 
@@ -203,7 +203,7 @@ TEST(private_kernel_tests, test_deposit)
 
     mock_kernel_circuit(mock_kernel_composer, mock_kernel_public_inputs);
 
-    UnrolledProver mock_kernel_prover = mock_kernel_composer.create_unrolled_prover();
+    Prover mock_kernel_prover = mock_kernel_composer.create_prover();
     NT::Proof mock_kernel_proof = mock_kernel_prover.construct_proof();
     // info("\nmock_kernel_proof: ", mock_kernel_proof.proof_data);
 

--- a/src/aztec3/circuits/kernel/private/init.hpp
+++ b/src/aztec3/circuits/kernel/private/init.hpp
@@ -16,7 +16,7 @@ namespace aztec3::circuits::kernel::private_kernel {
 
 // Turbo specific, at the moment:
 using Composer = plonk::stdlib::types::Composer;
-using plonk::stdlib::types::UnrolledProver;
+using plonk::stdlib::types::Prover;
 
 using Aggregator = aztec3::circuits::recursion::Aggregator;
 

--- a/src/aztec3/circuits/recursion/aggregator.hpp
+++ b/src/aztec3/circuits/recursion/aggregator.hpp
@@ -24,8 +24,8 @@ using transcript::Manifest;
 //     using AggregationObject = recursion_output<bn254>;
 
 //     // Native Types:
-//     using Proof = waffle::plonk_proof;
-//     using VK = std::shared_ptr<waffle::verification_key>;
+//     using Proof = plonk::proof;
+//     using VK = std::shared_ptr<bonk::verification_key>;
 
 //     static AggregationObject aggregate(Composer* composer,
 //                                        const VK& vk,
@@ -33,7 +33,7 @@ using transcript::Manifest;
 //                                        const AggregationObject recursion_output = AggregationObject())
 //     {
 //         std::shared_ptr<verification_key<bn254>> recursive_vk = verification_key<bn254>::from_witness(composer, vk);
-//         const transcript::Manifest recursive_manifest = Composer::create_unrolled_manifest(vk->num_public_inputs);
+//         const transcript::Manifest recursive_manifest = Composer::create_manifest(vk->num_public_inputs);
 
 //         AggregationObject result = verify_proof<bn254, recursive_inner_verifier_settings<bn254>>(
 //             composer, recursive_vk, recursive_manifest, proof, recursion_output);
@@ -50,7 +50,7 @@ class Aggregator {
                                            const size_t& num_public_inputs,
                                            const CT::AggregationObject recursion_output = CT::AggregationObject())
     {
-        const Manifest recursive_manifest = Composer::create_unrolled_manifest(num_public_inputs);
+        const Manifest recursive_manifest = Composer::create_manifest(num_public_inputs);
 
         CT::AggregationObject result = verify_proof<CT::bn254, recursive_inner_verifier_settings>(
             composer, vk, recursive_manifest, proof, recursion_output);

--- a/src/aztec3/circuits/recursion/play.test.cpp
+++ b/src/aztec3/circuits/recursion/play.test.cpp
@@ -9,7 +9,7 @@ using namespace plonk::stdlib::types;
 using plonk::stdlib::recursion::recursion_output;
 
 // namespace {
-// std::shared_ptr<waffle::DynamicFileReferenceStringFactory> srs;
+// std::shared_ptr<bonk::DynamicFileReferenceStringFactory> srs;
 // private_kernel::circuit_data private_kernel_cd;
 // private_circuit::circuit_data private_circuit_cd;
 // } // namespace
@@ -19,7 +19,7 @@ class play_tests : public ::testing::Test {
     //     static void SetUpTestCase()
     //     {
     //         std::string CRS_PATH = "../srs_db/ignition";
-    //         srs = std::make_shared<waffle::DynamicFileReferenceStringFactory>(CRS_PATH);
+    //         srs = std::make_shared<bonk::DynamicFileReferenceStringFactory>(CRS_PATH);
     //         private_circuit_cd = join_split::get_circuit_data(srs);
     //         private_kernel_cd = claim::get_circuit_data(srs);
     //     }
@@ -40,8 +40,8 @@ TEST(play_tests, test_play_app_proof_gen)
         info("Play app circuit logic failed: ", app_composer.err());
     }
 
-    Prover app_prover = app_composer.create_prover();
-    waffle::plonk_proof app_proof = app_prover.construct_proof();
+    stdlib::types::Prover app_prover = app_composer.create_prover();
+    proof app_proof = app_prover.construct_proof();
     info("app_proof: ", app_proof.proof_data);
 }
 
@@ -54,11 +54,11 @@ TEST(play_tests, test_play_recursive_proof_gen)
         info("Play app circuit logic failed: ", app_composer.err());
     }
 
-    Prover app_prover = app_composer.create_prover();
-    waffle::plonk_proof app_proof = app_prover.construct_proof();
+    stdlib::types::Prover app_prover = app_composer.create_prover();
+    proof app_proof = app_prover.construct_proof();
     info("app_proof: ", app_proof.proof_data);
 
-    std::shared_ptr<waffle::verification_key> app_vk = app_composer.compute_verification_key();
+    std::shared_ptr<bonk::verification_key> app_vk = app_composer.compute_verification_key();
 
     Composer recursive_composer = Composer("../barretenberg/cpp/srs_db/ignition");
     recursion_output<bn254> recursion_output = play_recursive_circuit(recursive_composer, app_vk, app_proof);
@@ -77,9 +77,9 @@ TEST(play_tests, test_play_recursive_2_proof_gen)
         info("Play app circuit logic failed: ", app_composer.err());
     }
 
-    Prover app_prover = app_composer.create_prover();
-    waffle::plonk_proof app_proof = app_prover.construct_proof();
-    std::shared_ptr<waffle::verification_key> app_vk = app_composer.compute_verification_key();
+    stdlib::types::Prover app_prover = app_composer.create_prover();
+    proof app_proof = app_prover.construct_proof();
+    std::shared_ptr<bonk::verification_key> app_vk = app_composer.compute_verification_key();
 
     //*******************************************************************************
 
@@ -90,9 +90,9 @@ TEST(play_tests, test_play_recursive_2_proof_gen)
         info("dummy_circuit logic failed: ", dummy_circuit_composer.err());
     }
 
-    Prover dummy_circuit_prover = dummy_circuit_composer.create_prover();
-    waffle::plonk_proof dummy_circuit_proof = dummy_circuit_prover.construct_proof();
-    std::shared_ptr<waffle::verification_key> dummy_circuit_vk = dummy_circuit_composer.compute_verification_key();
+    stdlib::types::Prover dummy_circuit_prover = dummy_circuit_composer.create_prover();
+    proof dummy_circuit_proof = dummy_circuit_prover.construct_proof();
+    std::shared_ptr<bonk::verification_key> dummy_circuit_vk = dummy_circuit_composer.compute_verification_key();
 
     //*******************************************************************************
 
@@ -104,11 +104,11 @@ TEST(play_tests, test_play_recursive_2_proof_gen)
         info("recursion_1 circuit logic failed: ", recursion_1_composer.err());
     }
 
-    Prover recursion_1_prover = recursion_1_composer.create_prover();
+    stdlib::types::Prover recursion_1_prover = recursion_1_composer.create_prover();
 
-    waffle::plonk_proof recursion_1_proof = recursion_1_prover.construct_proof();
+    proof recursion_1_proof = recursion_1_prover.construct_proof();
 
-    std::shared_ptr<waffle::verification_key> recursion_1_vk = recursion_1_composer.compute_verification_key();
+    std::shared_ptr<bonk::verification_key> recursion_1_vk = recursion_1_composer.compute_verification_key();
 
     //*******************************************************************************
 
@@ -121,8 +121,8 @@ TEST(play_tests, test_play_recursive_2_proof_gen)
     // }
 
     // Prover recursion_2_prover = recursion_2_composer.create_prover();
-    // waffle::plonk_proof recursion_2_proof = recursion_2_prover.construct_proof();
-    // std::shared_ptr<waffle::verification_key> recursion_2_vk = recursion_2_composer.compute_verification_key();
+    // proof recursion_2_proof = recursion_2_prover.construct_proof();
+    // std::shared_ptr<bonk::verification_key> recursion_2_vk = recursion_2_composer.compute_verification_key();
 }
 
 } // namespace aztec3::circuits::recursion

--- a/src/aztec3/circuits/recursion/play.test.cpp
+++ b/src/aztec3/circuits/recursion/play.test.cpp
@@ -40,7 +40,7 @@ TEST(play_tests, test_play_app_proof_gen)
         info("Play app circuit logic failed: ", app_composer.err());
     }
 
-    UnrolledProver app_prover = app_composer.create_unrolled_prover();
+    Prover app_prover = app_composer.create_prover();
     waffle::plonk_proof app_proof = app_prover.construct_proof();
     info("app_proof: ", app_proof.proof_data);
 }
@@ -54,7 +54,7 @@ TEST(play_tests, test_play_recursive_proof_gen)
         info("Play app circuit logic failed: ", app_composer.err());
     }
 
-    UnrolledProver app_prover = app_composer.create_unrolled_prover();
+    Prover app_prover = app_composer.create_prover();
     waffle::plonk_proof app_proof = app_prover.construct_proof();
     info("app_proof: ", app_proof.proof_data);
 
@@ -77,7 +77,7 @@ TEST(play_tests, test_play_recursive_2_proof_gen)
         info("Play app circuit logic failed: ", app_composer.err());
     }
 
-    UnrolledProver app_prover = app_composer.create_unrolled_prover();
+    Prover app_prover = app_composer.create_prover();
     waffle::plonk_proof app_proof = app_prover.construct_proof();
     std::shared_ptr<waffle::verification_key> app_vk = app_composer.compute_verification_key();
 
@@ -90,7 +90,7 @@ TEST(play_tests, test_play_recursive_2_proof_gen)
         info("dummy_circuit logic failed: ", dummy_circuit_composer.err());
     }
 
-    UnrolledProver dummy_circuit_prover = dummy_circuit_composer.create_unrolled_prover();
+    Prover dummy_circuit_prover = dummy_circuit_composer.create_prover();
     waffle::plonk_proof dummy_circuit_proof = dummy_circuit_prover.construct_proof();
     std::shared_ptr<waffle::verification_key> dummy_circuit_vk = dummy_circuit_composer.compute_verification_key();
 
@@ -104,7 +104,7 @@ TEST(play_tests, test_play_recursive_2_proof_gen)
         info("recursion_1 circuit logic failed: ", recursion_1_composer.err());
     }
 
-    UnrolledProver recursion_1_prover = recursion_1_composer.create_unrolled_prover();
+    Prover recursion_1_prover = recursion_1_composer.create_prover();
 
     waffle::plonk_proof recursion_1_proof = recursion_1_prover.construct_proof();
 
@@ -120,7 +120,7 @@ TEST(play_tests, test_play_recursive_2_proof_gen)
     //     info("recursion_2 circuit logic failed: ", recursion_2_composer.err());
     // }
 
-    // UnrolledProver recursion_2_prover = recursion_2_composer.create_unrolled_prover();
+    // Prover recursion_2_prover = recursion_2_composer.create_prover();
     // waffle::plonk_proof recursion_2_proof = recursion_2_prover.construct_proof();
     // std::shared_ptr<waffle::verification_key> recursion_2_vk = recursion_2_composer.compute_verification_key();
 }


### PR DESCRIPTION

# Description

Changing `UnrolledProver` -> `Prover` because there is only one prover in barretenberg now: Plonk prover that doesn't use the linearisation trick.

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] There are no circuit changes, OR specifications in `/specs` have been updated.
- [x] There are no circuit changes, OR a cryptographer has been assigned for review.
- [x] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
- [x] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [x] If existing code has been modified, such documentation has been added or updated.

> **Note**
> If you are updating the submodule, please make sure you do it in its own _special_ PR and avoid making changes to the submodule as a part of other PRs.
> To update a submodule, you can run the following commands:
> ```console
> $ git submodule update --recursive
> ```
> Alternatively, you can select a particular commit in `barretenberg/aztec3` that you wish to point to:
> ```console
> $ cd barretenberg
> $ git pull origin aztec3        # This will point to the latest commit in `barretenberg/aztec3`
> $ git checkout <commit_hash>    # Use this if you wish to point to a particular commit.
> $ cd ..
> $ git add . && git commit -m <commit_msg>
> $ git push
> ```
