### PR TITLE
Fix sibling path size in base rollup inputs

### DIFF
--- a/cpp/src/aztec3/circuits/abis/rollup/base/base_rollup_inputs.hpp
+++ b/cpp/src/aztec3/circuits/abis/rollup/base/base_rollup_inputs.hpp
@@ -31,7 +31,7 @@ template <typename NCT> struct BaseRollupInputs {
     // Note: the insertion leaf index can be derived from the above snapshots' `next_available_leaf_index` values.
     std::array<fr, PRIVATE_DATA_SUBTREE_INCLUSION_CHECK_DEPTH> new_commitments_subtree_sibling_path;
     std::array<fr, NULLIFIER_SUBTREE_INCLUSION_CHECK_DEPTH> new_nullifiers_subtree_sibling_path;
-    std::array<fr, NULLIFIER_SUBTREE_INCLUSION_CHECK_DEPTH> new_contracts_subtree_sibling_path;
+    std::array<fr, CONTRACT_SUBTREE_INCLUSION_CHECK_DEPTH> new_contracts_subtree_sibling_path;
 
     std::array<MembershipWitness<NCT, PRIVATE_DATA_TREE_ROOTS_TREE_HEIGHT>, 2>
         historic_private_data_tree_root_membership_witnesses;


### PR DESCRIPTION
Fixes serialization issue for base rollup inputs