### PR TITLE
Export rollup circuits cbinds

### DIFF
--- a/cpp/src/aztec3/CMakeLists.txt
+++ b/cpp/src/aztec3/CMakeLists.txt
@@ -13,7 +13,8 @@ if (WASM)
         aztec3-circuits.wasm
         $<TARGET_OBJECTS:aztec3_circuits_apps_objects>
         $<TARGET_OBJECTS:aztec3_circuits_abis_objects>
-        $<TARGET_OBJECTS:aztec3_circuits_kernel_objects>
+        $<TARGET_OBJECTS:aztec3_circuits_kernel_objects>        
+        $<TARGET_OBJECTS:aztec3_circuits_rollup_objects>
     )
     target_link_libraries(aztec3-circuits.wasm barretenberg)
 

--- a/cpp/src/aztec3/circuits/kernel/private/c_bind.h
+++ b/cpp/src/aztec3/circuits/kernel/private/c_bind.h
@@ -1,3 +1,4 @@
+#pragma once
 #include <cstdint>
 #include <cstddef>
 

--- a/cpp/src/aztec3/circuits/rollup/base/c_bind.cpp
+++ b/cpp/src/aztec3/circuits/rollup/base/c_bind.cpp
@@ -146,12 +146,12 @@ WASM_EXPORT size_t base_rollup__sim(uint8_t const* base_rollup_inputs_buf,
 //    return base_rollup_proof.proof_data.size();
 //}
 
-WASM_EXPORT size_t private_kernel__verify_proof(uint8_t const* vk_buf, uint8_t const* proof, uint32_t length)
-{
-    (void)vk_buf; // unused
-    (void)proof;  // unused
-    (void)length; // unused
-    return true;
-}
+// WASM_EXPORT size_t private_kernel__verify_proof(uint8_t const* vk_buf, uint8_t const* proof, uint32_t length)
+// {
+//     (void)vk_buf; // unused
+//     (void)proof;  // unused
+//     (void)length; // unused
+//     return true;
+// }
 
 } // extern "C"


### PR DESCRIPTION
Adds rollup circuit cbinds to the cmakelists so they can exported in the wasm to be consumed by aztec3-packages/circuits.js.