### PR TITLE
dangerous nonce nullifier

### DIFF
--- a/cpp/src/aztec3/circuits/kernel/private/native_private_kernel_circuit.cpp
+++ b/cpp/src/aztec3/circuits/kernel/private/native_private_kernel_circuit.cpp
@@ -125,6 +125,14 @@ void update_end_values(PrivateInputs<NT> const& private_inputs, PublicInputs<NT>
                                                                      native_new_contract_data);
     }
 
+    {
+        // Nonce nullifier
+        // DANGER: This is terrible. This should not be part of the protocol. This is an intentional bodge to reach a
+        // milestone. This must not be the way we derive nonce nullifiers in production. It can be front-run by other
+        // users. It is not domain separated. Naughty.
+        array_push(public_inputs.end.new_nullifiers, private_inputs.signed_tx_request.tx_request.nonce);
+    }
+
     { // commitments & nullifiers
         std::array<NT::fr, NEW_COMMITMENTS_LENGTH> siloed_new_commitments;
         for (size_t i = 0; i < new_commitments.size(); ++i) {


### PR DESCRIPTION
# Description

Pushing a nonce to the nullifiers array, to ensure 'uniqueness' of tx hashes.

This is not a secure long term solution.

It can be front-run

It is not domain separated.

It is not unique to a user.

Ship it. 

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] There are no circuit changes, OR specifications in `/specs` have been updated.
- [ ] There are no circuit changes, OR a cryptographer has been assigned for review.
- [ ] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [ ] The branch has been rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
- [ ] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [ ] If existing code has been modified, such documentation has been added or updated.

> **Note**
> If you are updating the submodule, please make sure you do it in its own _special_ PR and avoid making changes to the submodule as a part of other PRs.
> To update a submodule, you can run the following commands:
> ```console
> $ git submodule update --recursive
> ```
> Alternatively, you can select a particular commit in `barretenberg/aztec3` that you wish to point to:
> ```console
> $ cd barretenberg
> $ git pull origin aztec3        # This will point to the latest commit in `barretenberg/aztec3`
> $ git checkout <commit_hash>    # Use this if you wish to point to a particular commit.
> $ cd ..
> $ git add . && git commit -m <commit_msg>
> $ git push
> ```
