### PR TITLE
Test for public kernel inputs serialization

### DIFF
--- a/cpp/src/aztec3/circuits/abis/c_bind.cpp
+++ b/cpp/src/aztec3/circuits/abis/c_bind.cpp
@@ -13,6 +13,7 @@
 #include "rollup/root/root_rollup_inputs.hpp"
 #include "private_kernel/previous_kernel_data.hpp"
 #include "private_kernel/private_inputs.hpp"
+#include "private_kernel/public_inputs.hpp"
 
 #include <aztec3/constants.hpp>
 
@@ -446,6 +447,12 @@ WASM_EXPORT const char* abis__test_roundtrip_reserialize_root_rollup_public_inpu
 WASM_EXPORT const char* abis__test_roundtrip_serialize_private_kernel_inputs(uint8_t const* input, uint32_t* size)
 {
     return as_string_output<aztec3::circuits::abis::private_kernel::PrivateInputs<NT>>(input, size);
+}
+
+WASM_EXPORT const char* abis__test_roundtrip_serialize_private_kernel_public_inputs(uint8_t const* input,
+                                                                                    uint32_t* size)
+{
+    return as_string_output<aztec3::circuits::abis::private_kernel::PublicInputs<NT>>(input, size);
 }
 
 } // extern "C"


### PR DESCRIPTION
Serialization test for `aztec3::circuits::abis::private_kernel::PublicInputs`