### PR TITLE
Valid contract address should be known in constructor

### DIFF
--- a/cpp/src/aztec3/circuits/apps/test_apps/basic_contract_deployment/basic_contract_deployment.cpp
+++ b/cpp/src/aztec3/circuits/apps/test_apps/basic_contract_deployment/basic_contract_deployment.cpp
@@ -50,7 +50,7 @@ OptionalPrivateCircuitPublicInputs<NT> constructor(FunctionExecutionContext& exe
 
     exec_ctx.finalise();
 
-    info("public inputs: ", public_inputs);
+    // info("public inputs: ", public_inputs);
 
     return public_inputs.to_native_type<C>();
 }

--- a/cpp/src/aztec3/circuits/apps/test_apps/escrow/deposit.cpp
+++ b/cpp/src/aztec3/circuits/apps/test_apps/escrow/deposit.cpp
@@ -62,7 +62,7 @@ OptionalPrivateCircuitPublicInputs<NT> deposit(FunctionExecutionContext& exec_ct
 
     exec_ctx.finalise();
 
-    info("public inputs: ", public_inputs);
+    // info("public inputs: ", public_inputs);
 
     return public_inputs.to_native_type<C>();
     // TODO: also return note preimages and nullifier preimages.

--- a/cpp/src/aztec3/circuits/apps/test_apps/escrow/transfer.cpp
+++ b/cpp/src/aztec3/circuits/apps/test_apps/escrow/transfer.cpp
@@ -105,7 +105,7 @@ OptionalPrivateCircuitPublicInputs<NT> transfer(FunctionExecutionContext& exec_c
 
     exec_ctx.finalise();
 
-    info("public inputs: ", public_inputs);
+    // info("public inputs: ", public_inputs);
 
     return public_inputs.to_native_type<C>();
 };

--- a/cpp/src/aztec3/circuits/apps/test_apps/escrow/withdraw.cpp
+++ b/cpp/src/aztec3/circuits/apps/test_apps/escrow/withdraw.cpp
@@ -97,7 +97,7 @@ OptionalPrivateCircuitPublicInputs<NT> withdraw(FunctionExecutionContext& exec_c
     /// TODO: merkle membership check
     // public_inputs.historic_private_data_tree_root
 
-    info("public inputs: ", public_inputs);
+    // info("public inputs: ", public_inputs);
 
     return public_inputs.to_native_type<C>();
 };

--- a/cpp/src/aztec3/circuits/apps/test_apps/private_to_private_function_call/function_2_1.cpp
+++ b/cpp/src/aztec3/circuits/apps/test_apps/private_to_private_function_call/function_2_1.cpp
@@ -68,7 +68,7 @@ void function_2_1(FunctionExecutionContext& exec_ctx, std::array<NT::fr, ARGS_LE
 
     exec_ctx.finalise();
 
-    info("public inputs: ", public_inputs);
+    // info("public inputs: ", public_inputs);
 
     // TODO: also return note preimages and nullifier preimages.
 };

--- a/cpp/src/aztec3/circuits/kernel/private/native_private_kernel_circuit.cpp
+++ b/cpp/src/aztec3/circuits/kernel/private/native_private_kernel_circuit.cpp
@@ -83,15 +83,9 @@ void update_end_values(PrivateInputs<NT> const& private_inputs, PublicInputs<NT>
     const auto& contract_deployment_data =
         private_inputs.signed_tx_request.tx_request.tx_context.contract_deployment_data;
 
-    { // contracts
+    { // contract deployment
         // input storage contract address must be 0 if its a constructor call and non-zero otherwise
         auto is_contract_deployment = public_inputs.constants.tx_context.is_contract_deployment_tx;
-
-        if (is_contract_deployment) {
-            ASSERT(storage_contract_address == 0);
-        } else {
-            ASSERT(storage_contract_address != 0);
-        }
 
         auto private_call_vk_hash = stdlib::recursion::verification_key<CT::bn254>::compress_native(
             private_inputs.private_call.vk, GeneratorIndex::VK);
@@ -108,6 +102,14 @@ void update_end_values(PrivateInputs<NT> const& private_inputs, PublicInputs<NT>
                                                              contract_deployment_data.contract_address_salt,
                                                              contract_deployment_data.function_tree_root,
                                                              constructor_hash);
+
+        if (is_contract_deployment) {
+            // must imply == derived address
+            ASSERT(storage_contract_address == contract_address);
+        } else {
+            // non-contract deployments must specify contract address being interacted with
+            ASSERT(storage_contract_address != 0);
+        }
 
         // compute contract address nullifier
         auto blake_input = contract_address.to_field().to_buffer();


### PR DESCRIPTION
# Description

Valid contract address should be known in constructor and should be input to private kernel even for contract deployment.

## Slack conversation summarized:
"""
Alvaro Rodriguez
During constructor execution, call_context.storage_contract_address  should be the precomputed contract address right? not zero

(in the noir context)

I was exposing zero and changed it to the precomputed contract address in the acir simulator and everything seems to work

But i don't know how the real private kernel will handle that

Mike
Hmm... well actually...
At the moment, the private kernel computes the new contract address and will then hash any new_commitments with the new contract address.
Edit: it also enforces that the value is 0 in the case of a constructor, so that would need to change.
Does a constructor function need to 'know' about its own contract address?
Can you access address(this) inside a Solidity constructor?

Alvaro Rodriguez
I think that the noir code is also siloing commitments :confused: we should remove that
But if i remember correctly i think that the constructor in solidity can know its own address. It also can call other contracts that use msg.sender, for example

Mike
The Noir code should silo the commitment when it does a read (get). But not when it does a write (insert).

Alvaro Rodriguez
Yeah, on read you need it for merkle membership, but it was siloing on write

https://github.com/AztecProtocol/aztec3-packages/blob/master/yarn-project/noir-contracts/src/contracts/noir-aztec3/src/set.nr#L77

Mike
Ah, well spotted, please could you update that when you get a chance?

Alvaro Rodriguez
yep!

Mike
But if i remember correctly i think that the constructor in solidity can know its own address
I just checked and you can. So we should update the call_context to always have a nonzero storage_contract_address.
@dbanks12  this might be a nice thing for you to try to update in the Private Kernel Circuit logic. At the moment we enforce that the storage_contract_address is zero (in the case of executing a constructor), but we should instead check that this value matches the contract address which we derive. (Should be a very tiny change).

Leila
I think we can still continue to have the to field of the TxRequest be 0 (in the case of contract deployment). So we shouldn't need a change there.

TxRequest.to is always the contract address, for both regular tx and contract deployment.

Mike
Oh, cool

@dbanks12 please can you also check that the kernel circuit isn't enforcing a 0 in the to field of the TxRequest :sweat_smile:
"""

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] There are no circuit changes, OR specifications in `/specs` have been updated.
- [x] There are no circuit changes, OR a cryptographer has been assigned for review.
- [x] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [ ] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
- [x] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [x] If existing code has been modified, such documentation has been added or updated.

> **Note**
> If you are updating the submodule, please make sure you do it in its own _special_ PR and avoid making changes to the submodule as a part of other PRs.
> To update a submodule, you can run the following commands:
> ```console
> $ git submodule update --recursive
> ```
> Alternatively, you can select a particular commit in `barretenberg/aztec3` that you wish to point to:
> ```console
> $ cd barretenberg
> $ git pull origin aztec3        # This will point to the latest commit in `barretenberg/aztec3`
> $ git checkout <commit_hash>    # Use this if you wish to point to a particular commit.
> $ cd ..
> $ git add . && git commit -m <commit_msg>
> $ git push
> ```
