### PR TITLE
Reusable rollup components

### DIFF
--- a/cpp/src/aztec3/circuits/abis/rollup/base/base_or_merge_rollup_public_inputs.hpp
+++ b/cpp/src/aztec3/circuits/abis/rollup/base/base_or_merge_rollup_public_inputs.hpp
@@ -27,6 +27,9 @@ template <typename NCT> struct BaseOrMergeRollupPublicInputs {
 
     AggregationObject end_aggregation_object;
     ConstantRollupData<NCT> constants;
+    // subtree  height is always 0 for base.
+    // so that we always pass-in two base/merge circuits of the same height into the next level of recursion
+    fr rollup_subtree_height;
 
     AppendOnlyTreeSnapshot<NCT> start_private_data_tree_snapshot;
     AppendOnlyTreeSnapshot<NCT> end_private_data_tree_snapshot;
@@ -52,6 +55,7 @@ template <typename NCT> void read(uint8_t const*& it, BaseOrMergeRollupPublicInp
     read(it, obj.rollup_subtree_height);
     read(it, obj.end_aggregation_object);
     read(it, obj.constants);
+    read(it, obj.rollup_subtree_height);
     read(it, obj.start_private_data_tree_snapshot);
     read(it, obj.end_private_data_tree_snapshot);
     read(it, obj.start_nullifier_tree_snapshot);
@@ -69,6 +73,7 @@ template <typename NCT> void write(std::vector<uint8_t>& buf, BaseOrMergeRollupP
     write(buf, obj.rollup_subtree_height);
     write(buf, obj.end_aggregation_object);
     write(buf, obj.constants);
+    write(buf, obj.rollup_subtree_height);
     write(buf, obj.start_private_data_tree_snapshot);
     write(buf, obj.end_private_data_tree_snapshot);
     write(buf, obj.start_nullifier_tree_snapshot);
@@ -89,6 +94,9 @@ template <typename NCT> std::ostream& operator<<(std::ostream& os, BaseOrMergeRo
               << "\n"
                  "constants:\n"
               << obj.constants
+              << "\n"
+                 "rollup_subtree_height:\n"
+              << obj.rollup_subtree_height
               << "\n"
                  "start_private_data_tree_snapshot:\n"
               << obj.start_private_data_tree_snapshot

--- a/cpp/src/aztec3/circuits/abis/rollup/base/base_or_merge_rollup_public_inputs.hpp
+++ b/cpp/src/aztec3/circuits/abis/rollup/base/base_or_merge_rollup_public_inputs.hpp
@@ -27,9 +27,6 @@ template <typename NCT> struct BaseOrMergeRollupPublicInputs {
 
     AggregationObject end_aggregation_object;
     ConstantRollupData<NCT> constants;
-    // subtree  height is always 0 for base.
-    // so that we always pass-in two base/merge circuits of the same height into the next level of recursion
-    fr rollup_subtree_height;
 
     AppendOnlyTreeSnapshot<NCT> start_private_data_tree_snapshot;
     AppendOnlyTreeSnapshot<NCT> end_private_data_tree_snapshot;
@@ -55,7 +52,6 @@ template <typename NCT> void read(uint8_t const*& it, BaseOrMergeRollupPublicInp
     read(it, obj.rollup_subtree_height);
     read(it, obj.end_aggregation_object);
     read(it, obj.constants);
-    read(it, obj.rollup_subtree_height);
     read(it, obj.start_private_data_tree_snapshot);
     read(it, obj.end_private_data_tree_snapshot);
     read(it, obj.start_nullifier_tree_snapshot);
@@ -73,7 +69,6 @@ template <typename NCT> void write(std::vector<uint8_t>& buf, BaseOrMergeRollupP
     write(buf, obj.rollup_subtree_height);
     write(buf, obj.end_aggregation_object);
     write(buf, obj.constants);
-    write(buf, obj.rollup_subtree_height);
     write(buf, obj.start_private_data_tree_snapshot);
     write(buf, obj.end_private_data_tree_snapshot);
     write(buf, obj.start_nullifier_tree_snapshot);
@@ -94,9 +89,6 @@ template <typename NCT> std::ostream& operator<<(std::ostream& os, BaseOrMergeRo
               << "\n"
                  "constants:\n"
               << obj.constants
-              << "\n"
-                 "rollup_subtree_height:\n"
-              << obj.rollup_subtree_height
               << "\n"
                  "start_private_data_tree_snapshot:\n"
               << obj.start_private_data_tree_snapshot

--- a/cpp/src/aztec3/circuits/rollup/base/native_base_rollup_circuit.cpp
+++ b/cpp/src/aztec3/circuits/rollup/base/native_base_rollup_circuit.cpp
@@ -521,7 +521,6 @@ BaseOrMergeRollupPublicInputs base_rollup_circuit(DummyComposer& composer, BaseR
         .rollup_subtree_height = fr(0),
         .end_aggregation_object = aggregation_object,
         .constants = baseRollupInputs.constants,
-        .rollup_subtree_height = fr(0),
         .start_private_data_tree_snapshot = baseRollupInputs.start_private_data_tree_snapshot,
         .end_private_data_tree_snapshot = end_private_data_tree_snapshot,
         .start_nullifier_tree_snapshot = baseRollupInputs.start_nullifier_tree_snapshot,

--- a/cpp/src/aztec3/circuits/rollup/base/native_base_rollup_circuit.cpp
+++ b/cpp/src/aztec3/circuits/rollup/base/native_base_rollup_circuit.cpp
@@ -521,6 +521,7 @@ BaseOrMergeRollupPublicInputs base_rollup_circuit(DummyComposer& composer, BaseR
         .rollup_subtree_height = fr(0),
         .end_aggregation_object = aggregation_object,
         .constants = baseRollupInputs.constants,
+        .rollup_subtree_height = fr(0),
         .start_private_data_tree_snapshot = baseRollupInputs.start_private_data_tree_snapshot,
         .end_private_data_tree_snapshot = end_private_data_tree_snapshot,
         .start_nullifier_tree_snapshot = baseRollupInputs.start_nullifier_tree_snapshot,

--- a/cpp/src/aztec3/circuits/rollup/components/components.cpp
+++ b/cpp/src/aztec3/circuits/rollup/components/components.cpp
@@ -1,0 +1,128 @@
+#include "aztec3/circuits/abis/rollup/base/base_or_merge_rollup_public_inputs.hpp"
+#include "aztec3/constants.hpp"
+#include "barretenberg/crypto/pedersen_hash/pedersen.hpp"
+#include "barretenberg/crypto/sha256/sha256.hpp"
+#include "barretenberg/ecc/curves/bn254/fr.hpp"
+#include "barretenberg/stdlib/hash/pedersen/pedersen.hpp"
+#include "init.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cassert>
+#include <cstdint>
+#include <tuple>
+#include <vector>
+
+namespace aztec3::circuits::rollup::components {
+
+/**
+ * @brief Create an aggregation object for the proofs that are provided
+ *          - We add points P0 for each of our proofs
+ *          - We add points P1 for each of our proofs
+ *          - We concat our public inputs
+ *
+ * @param mergeRollupInputs
+ * @return AggregationObject
+ */
+AggregationObject aggregate_proofs(BaseOrMergeRollupPublicInputs const& left,
+                                   BaseOrMergeRollupPublicInputs const& right)
+{
+    // TODO: NOTE: for now we simply return the aggregation object from the first proof
+    (void)right;
+    return left.end_aggregation_object;
+}
+
+/**
+ * @brief Asserts that the rollup types are the same
+ *
+ * @param left - The public inputs of the left rollup (base or merge)
+ * @param right - The public inputs of the right rollup (base or merge)
+ */
+void assert_both_input_proofs_of_same_rollup_type(DummyComposer& composer,
+                                                  BaseOrMergeRollupPublicInputs const& left,
+                                                  BaseOrMergeRollupPublicInputs const& right)
+{
+    composer.do_assert(left.rollup_type == right.rollup_type, "input proofs are of different rollup types");
+}
+
+/**
+ * @brief Asserts that the rollup subtree heights are the same and returns the height
+ *
+ * @param left - The public inputs of the left rollup (base or merge)
+ * @param right - The public inputs of the right rollup (base or merge)
+ * @return NT::fr - The height of the rollup subtrees
+ */
+NT::fr assert_both_input_proofs_of_same_height_and_return(DummyComposer& composer,
+                                                          BaseOrMergeRollupPublicInputs const& left,
+                                                          BaseOrMergeRollupPublicInputs const& right)
+{
+    composer.do_assert(left.rollup_subtree_height == right.rollup_subtree_height,
+                       "input proofs are of different rollup heights");
+    return left.rollup_subtree_height;
+}
+
+/**
+ * @brief Asserts that the constants used in the left and right child are identical
+ *
+ * @param left - The public inputs of the left rollup (base or merge)
+ * @param right - The public inputs of the right rollup (base or merge)
+ */
+void assert_equal_constants(DummyComposer& composer,
+                            BaseOrMergeRollupPublicInputs const& left,
+                            BaseOrMergeRollupPublicInputs const& right)
+{
+    composer.do_assert(left.constants == right.constants, "input proofs have different constants");
+}
+
+// Generates a 512 bit input from right and left 256 bit hashes. Then computes the sha256, and splits the hash into two
+// field elements, a high and a low that is returned.
+std::array<fr, 2> compute_calldata_hash(std::array<abis::PreviousRollupData<NT>, 2> previous_rollup_data)
+{
+    // Generate a 512 bit input from right and left 256 bit hashes
+    std::array<uint8_t, 2 * 32> calldata_hash_input_bytes;
+    for (uint8_t i = 0; i < 2; i++) {
+        std::array<fr, 2> calldata_hash_fr = previous_rollup_data[i].base_or_merge_rollup_public_inputs.calldata_hash;
+
+        auto high_buffer = calldata_hash_fr[0].to_buffer();
+        auto low_buffer = calldata_hash_fr[1].to_buffer();
+
+        for (uint8_t j = 0; j < 16; ++j) {
+            calldata_hash_input_bytes[i * 32 + j] = high_buffer[16 + j];
+            calldata_hash_input_bytes[i * 32 + 16 + j] = low_buffer[16 + j];
+        }
+    }
+
+    // Compute the sha256
+    std::vector<uint8_t> calldata_hash_input_bytes_vec(calldata_hash_input_bytes.begin(),
+                                                       calldata_hash_input_bytes.end());
+    auto h = sha256::sha256(calldata_hash_input_bytes_vec);
+
+    // Split the hash into two fields, a high and a low
+    std::array<uint8_t, 32> buf_1, buf_2;
+    for (uint8_t i = 0; i < 16; i++) {
+        buf_1[i] = 0;
+        buf_1[16 + i] = h[i];
+        buf_2[i] = 0;
+        buf_2[16 + i] = h[i + 16];
+    }
+    auto high = fr::serialize_from_buffer(buf_1.data());
+    auto low = fr::serialize_from_buffer(buf_2.data());
+
+    return { high, low };
+}
+
+// asserts that the end snapshot of previous_rollup 0 equals the start snapshot of previous_rollup 1 (i.e. ensure they
+// follow on from one-another). Ensures that right uses the tres that was updated by left.
+void assert_prev_rollups_follow_on_from_each_other(DummyComposer& composer,
+                                                   BaseOrMergeRollupPublicInputs const& left,
+                                                   BaseOrMergeRollupPublicInputs const& right)
+{
+    composer.do_assert(left.end_private_data_tree_snapshot == right.start_private_data_tree_snapshot,
+                       "input proofs have different private data tree snapshots");
+    composer.do_assert(left.end_nullifier_tree_snapshot == right.start_nullifier_tree_snapshot,
+                       "input proofs have different nullifier tree snapshots");
+    composer.do_assert(left.end_contract_tree_snapshot == right.start_contract_tree_snapshot,
+                       "input proofs have different contract tree snapshots");
+}
+
+} // namespace aztec3::circuits::rollup::components

--- a/cpp/src/aztec3/circuits/rollup/components/components.hpp
+++ b/cpp/src/aztec3/circuits/rollup/components/components.hpp
@@ -17,16 +17,17 @@ void assert_equal_constants(DummyComposer& composer,
                             BaseOrMergeRollupPublicInputs const& left,
                             BaseOrMergeRollupPublicInputs const& right);
 
-AggregationObject aggregate_proofs(BaseOrMergeRollupPublicInputs const& left, BaseOrMergeRollupPublicInputs const& right);
+AggregationObject aggregate_proofs(BaseOrMergeRollupPublicInputs const& left,
+                                   BaseOrMergeRollupPublicInputs const& right);
 
 template <size_t N>
 NT::fr iterate_through_tree_via_sibling_path(NT::fr leaf, NT::uint32 leafIndex, std::array<NT::fr, N> siblingPath)
 {
     for (size_t i = 0; i < siblingPath.size(); i++) {
         if (leafIndex & (1 << i)) {
-            leaf = crypto::pedersen_hash::hash_multiple({ siblingPath[i], leaf });
+            leaf = proof_system::plonk::stdlib::merkle_tree::hash_pair_native(siblingPath[i], leaf);
         } else {
-            leaf = crypto::pedersen_hash::hash_multiple({ leaf, siblingPath[i] });
+            leaf = proof_system::plonk::stdlib::merkle_tree::hash_pair_native(leaf, siblingPath[i]);
         }
     }
     return leaf;

--- a/cpp/src/aztec3/circuits/rollup/components/components.hpp
+++ b/cpp/src/aztec3/circuits/rollup/components/components.hpp
@@ -1,0 +1,72 @@
+#pragma once
+
+#include "init.hpp"
+
+namespace aztec3::circuits::rollup::components {
+std::array<fr, 2> compute_calldata_hash(std::array<abis::PreviousRollupData<NT>, 2> previous_rollup_data);
+void assert_prev_rollups_follow_on_from_each_other(DummyComposer& composer,
+                                                   BaseOrMergeRollupPublicInputs const& left,
+                                                   BaseOrMergeRollupPublicInputs const& right);
+void assert_both_input_proofs_of_same_rollup_type(DummyComposer& composer,
+                                                  BaseOrMergeRollupPublicInputs const& left,
+                                                  BaseOrMergeRollupPublicInputs const& right);
+NT::fr assert_both_input_proofs_of_same_height_and_return(DummyComposer& composer,
+                                                          BaseOrMergeRollupPublicInputs const& left,
+                                                          BaseOrMergeRollupPublicInputs const& right);
+void assert_equal_constants(DummyComposer& composer,
+                            BaseOrMergeRollupPublicInputs const& left,
+                            BaseOrMergeRollupPublicInputs const& right);
+
+AggregationObject aggregate_proofs(BaseOrMergeRollupPublicInputs const& left, BaseOrMergeRollupPublicInputs const& right);
+
+template <size_t N>
+NT::fr iterate_through_tree_via_sibling_path(NT::fr leaf, NT::uint32 leafIndex, std::array<NT::fr, N> siblingPath)
+{
+    for (size_t i = 0; i < siblingPath.size(); i++) {
+        if (leafIndex & (1 << i)) {
+            leaf = crypto::pedersen_hash::hash_multiple({ siblingPath[i], leaf });
+        } else {
+            leaf = crypto::pedersen_hash::hash_multiple({ leaf, siblingPath[i] });
+        }
+    }
+    return leaf;
+}
+
+template <size_t N>
+void check_membership(DummyComposer& composer,
+                      NT::fr const& leaf,
+                      NT::uint32 const& leafIndex,
+                      std::array<NT::fr, N> const& siblingPath,
+                      NT::fr const& root)
+{
+    auto calculatedRoot = iterate_through_tree_via_sibling_path(leaf, leafIndex, siblingPath);
+    // TODO: update tests to build the correct trees
+    composer.do_assert(calculatedRoot == root, "Membership check failed");
+}
+
+template <size_t N>
+AppendOnlySnapshot insert_subtree_to_snapshot_tree(DummyComposer& composer,
+                                                   AppendOnlySnapshot snapshot,
+                                                   std::array<NT::fr, N> siblingPath,
+                                                   NT::fr emptySubtreeRoot,
+                                                   NT::fr subtreeRootToInsert,
+                                                   uint8_t subtreeDepth)
+{
+    // TODO: Sanity check len of siblingPath > height of subtree
+    // TODO: Ensure height of subtree is correct (eg 3 for commitments, 1 for contracts)
+    auto leafIndexAtDepth = snapshot.next_available_leaf_index >> subtreeDepth;
+
+    // Check that the current root is correct and that there is an empty subtree at the insertion location
+    check_membership(composer, emptySubtreeRoot, leafIndexAtDepth, siblingPath, snapshot.root);
+
+    // if index of leaf is x, index of its parent is x/2 or x >> 1. We need to find the parent `subtreeDepth` levels up.
+    auto new_root = iterate_through_tree_via_sibling_path(subtreeRootToInsert, leafIndexAtDepth, siblingPath);
+
+    // 2^subtreeDepth is the number of leaves added. 2^x = 1 << x
+    auto new_next_available_leaf_index = snapshot.next_available_leaf_index + (uint8_t(1) << subtreeDepth);
+
+    AppendOnlySnapshot newTreeSnapshot = { .root = new_root,
+                                           .next_available_leaf_index = new_next_available_leaf_index };
+    return newTreeSnapshot;
+}
+} // namespace aztec3::circuits::rollup::components

--- a/cpp/src/aztec3/circuits/rollup/components/init.hpp
+++ b/cpp/src/aztec3/circuits/rollup/components/init.hpp
@@ -2,9 +2,9 @@
 #pragma once
 
 #include "aztec3/circuits/abis/append_only_tree_snapshot.hpp"
-#include "aztec3/circuits/abis/rollup/root/root_rollup_inputs.hpp"
 #include "aztec3/circuits/abis/rollup/constant_rollup_data.hpp"
-#include "aztec3/circuits/abis/rollup/root/root_rollup_public_inputs.hpp"
+#include "aztec3/circuits/abis/rollup/base/base_or_merge_rollup_public_inputs.hpp"
+#include "aztec3/circuits/abis/rollup/merge/merge_rollup_inputs.hpp"
 #include <aztec3/circuits/recursion/aggregator.hpp>
 #include <aztec3/circuits/abis/private_circuit_public_inputs.hpp>
 #include "aztec3/utils/dummy_composer.hpp"
@@ -15,16 +15,15 @@
 #include <aztec3/utils/types/circuit_types.hpp>
 #include <aztec3/utils/types/native_types.hpp>
 
-namespace aztec3::circuits::rollup::native_root_rollup {
+namespace aztec3::circuits::rollup::components {
 
 using NT = aztec3::utils::types::NativeTypes;
-using DummyComposer = aztec3::utils::DummyComposer;
 
 // Params
-using ConstantRollupData = abis::ConstantRollupData<NT>;
-using RootRollupInputs = abis::RootRollupInputs<NT>;
-using RootRollupPublicInputs = abis::RootRollupPublicInputs<NT>;
+using NT = aztec3::utils::types::NativeTypes;
+using AggregationObject = aztec3::utils::types::NativeTypes::AggregationObject;
+using BaseOrMergeRollupPublicInputs = aztec3::circuits::abis::BaseOrMergeRollupPublicInputs<NT>;
+using AppendOnlySnapshot = abis::AppendOnlyTreeSnapshot<NT>;
+using DummyComposer = aztec3::utils::DummyComposer;
 
-using Aggregator = aztec3::circuits::recursion::Aggregator;
-
-} // namespace aztec3::circuits::rollup::native_root_rollup
+} // namespace aztec3::circuits::rollup::components

--- a/cpp/src/aztec3/circuits/rollup/merge/native_merge_rollup_circuit.cpp
+++ b/cpp/src/aztec3/circuits/rollup/merge/native_merge_rollup_circuit.cpp
@@ -9,6 +9,8 @@
 #include "barretenberg/stdlib/merkle_tree/merkle_tree.hpp"
 #include "init.hpp"
 
+#include <aztec3/circuits/rollup/components/components.hpp>
+
 #include <algorithm>
 #include <array>
 #include <cassert>
@@ -17,116 +19,6 @@
 #include <vector>
 
 namespace aztec3::circuits::rollup::native_merge_rollup {
-
-/**
- * @brief Create an aggregation object for the proofs that are provided
- *          - We add points P0 for each of our proofs
- *          - We add points P1 for each of our proofs
- *          - We concat our public inputs
- *
- * @param mergeRollupInputs
- * @return AggregationObject
- */
-AggregationObject aggregate_proofs(BaseOrMergeRollupPublicInputs const& left,
-                                   BaseOrMergeRollupPublicInputs const& right)
-{
-    // TODO: NOTE: for now we simply return the aggregation object from the first proof
-    (void)right;
-    return left.end_aggregation_object;
-}
-
-/**
- * @brief Asserts that the rollup types are the same
- *
- * @param left - The public inputs of the left rollup (base or merge)
- * @param right - The public inputs of the right rollup (base or merge)
- */
-void assert_both_input_proofs_of_same_rollup_type(DummyComposer& composer,
-                                                  BaseOrMergeRollupPublicInputs const& left,
-                                                  BaseOrMergeRollupPublicInputs const& right)
-{
-    composer.do_assert(left.rollup_type == right.rollup_type, "input proofs are of different rollup types");
-}
-
-/**
- * @brief Asserts that the rollup subtree heights are the same and returns the height
- *
- * @param left - The public inputs of the left rollup (base or merge)
- * @param right - The public inputs of the right rollup (base or merge)
- * @return NT::fr - The height of the rollup subtrees
- */
-NT::fr assert_both_input_proofs_of_same_height_and_return(DummyComposer& composer,
-                                                          BaseOrMergeRollupPublicInputs const& left,
-                                                          BaseOrMergeRollupPublicInputs const& right)
-{
-    composer.do_assert(left.rollup_subtree_height == right.rollup_subtree_height,
-                       "input proofs are of different rollup heights");
-    return left.rollup_subtree_height;
-}
-
-/**
- * @brief Asserts that the constants used in the left and right child are identical
- *
- * @param left - The public inputs of the left rollup (base or merge)
- * @param right - The public inputs of the right rollup (base or merge)
- */
-void assert_equal_constants(DummyComposer& composer,
-                            BaseOrMergeRollupPublicInputs const& left,
-                            BaseOrMergeRollupPublicInputs const& right)
-{
-    composer.do_assert(left.constants == right.constants, "input proofs have different constants");
-}
-
-// Generates a 512 bit input from right and left 256 bit hashes. Then computes the sha256, and splits the hash into two
-// field elements, a high and a low that is returned.
-std::array<fr, 2> compute_calldata_hash(std::array<abis::PreviousRollupData<NT>, 2> const& previous_rollup_data)
-{
-    // Generate a 512 bit input from right and left 256 bit hashes
-    std::array<uint8_t, 2 * 32> calldata_hash_input_bytes;
-    for (uint8_t i = 0; i < 2; i++) {
-        std::array<fr, 2> calldata_hash_fr = previous_rollup_data[i].base_or_merge_rollup_public_inputs.calldata_hash;
-
-        auto high_buffer = calldata_hash_fr[0].to_buffer();
-        auto low_buffer = calldata_hash_fr[1].to_buffer();
-
-        for (uint8_t j = 0; j < 16; ++j) {
-            calldata_hash_input_bytes[i * 32 + j] = high_buffer[16 + j];
-            calldata_hash_input_bytes[i * 32 + 16 + j] = low_buffer[16 + j];
-        }
-    }
-
-    // Compute the sha256
-    std::vector<uint8_t> calldata_hash_input_bytes_vec(calldata_hash_input_bytes.begin(),
-                                                       calldata_hash_input_bytes.end());
-    auto h = sha256::sha256(calldata_hash_input_bytes_vec);
-
-    // Split the hash into two fields, a high and a low
-    std::array<uint8_t, 32> buf_1, buf_2;
-    for (uint8_t i = 0; i < 16; i++) {
-        buf_1[i] = 0;
-        buf_1[16 + i] = h[i];
-        buf_2[i] = 0;
-        buf_2[16 + i] = h[i + 16];
-    }
-    auto high = fr::serialize_from_buffer(buf_1.data());
-    auto low = fr::serialize_from_buffer(buf_2.data());
-
-    return { high, low };
-}
-
-// asserts that the end snapshot of previous_rollup 0 equals the start snapshot of previous_rollup 1 (i.e. ensure they
-// follow on from one-another). Ensures that right uses the tres that was updated by left.
-void assert_prev_rollups_follow_on_from_each_other(DummyComposer& composer,
-                                                   BaseOrMergeRollupPublicInputs const& left,
-                                                   BaseOrMergeRollupPublicInputs const& right)
-{
-    composer.do_assert(left.end_private_data_tree_snapshot == right.start_private_data_tree_snapshot,
-                       "input proofs have different private data tree snapshots");
-    composer.do_assert(left.end_nullifier_tree_snapshot == right.start_nullifier_tree_snapshot,
-                       "input proofs have different nullifier tree snapshots");
-    composer.do_assert(left.end_contract_tree_snapshot == right.start_contract_tree_snapshot,
-                       "input proofs have different contract tree snapshots");
-}
 
 BaseOrMergeRollupPublicInputs merge_rollup_circuit(DummyComposer& composer, MergeRollupInputs const& mergeRollupInputs)
 {
@@ -139,14 +31,14 @@ BaseOrMergeRollupPublicInputs merge_rollup_circuit(DummyComposer& composer, Merg
 
     // check that both input proofs are either both "BASE" or "MERGE" and not a mix!
     // this prevents having wonky commitment, nullifier and contract subtrees.
-    AggregationObject aggregation_object = aggregate_proofs(left, right);
-    assert_both_input_proofs_of_same_rollup_type(composer, left, right);
-    auto current_height = assert_both_input_proofs_of_same_height_and_return(composer, left, right);
-    assert_equal_constants(composer, left, right);
-    assert_prev_rollups_follow_on_from_each_other(composer, left, right);
+    AggregationObject aggregation_object = components::aggregate_proofs(left, right);
+    components::assert_both_input_proofs_of_same_rollup_type(composer, left, right);
+    auto current_height = components::assert_both_input_proofs_of_same_height_and_return(composer, left, right);
+    components::assert_equal_constants(composer, left, right);
+    components::assert_prev_rollups_follow_on_from_each_other(composer, left, right);
 
     // compute calldata hash:
-    auto new_calldata_hash = compute_calldata_hash(mergeRollupInputs.previous_rollup_data);
+    auto new_calldata_hash = components::compute_calldata_hash(mergeRollupInputs.previous_rollup_data);
 
     BaseOrMergeRollupPublicInputs public_inputs = {
         .rollup_type = abis::MERGE_ROLLUP_TYPE,

--- a/cpp/src/aztec3/circuits/rollup/merge/native_merge_rollup_circuit.hpp
+++ b/cpp/src/aztec3/circuits/rollup/merge/native_merge_rollup_circuit.hpp
@@ -13,20 +13,4 @@
 namespace aztec3::circuits::rollup::native_merge_rollup {
 
 BaseOrMergeRollupPublicInputs merge_rollup_circuit(DummyComposer& composer, MergeRollupInputs const& mergeRollupInputs);
-
-std::array<fr, 2> compute_calldata_hash(std::array<abis::PreviousRollupData<NT>, 2> const& previous_rollup_data);
-void assert_prev_rollups_follow_on_from_each_other(DummyComposer& composer,
-                                                   BaseOrMergeRollupPublicInputs const& left,
-                                                   BaseOrMergeRollupPublicInputs const& right);
-void assert_both_input_proofs_of_same_rollup_type(DummyComposer& composer,
-                                                  BaseOrMergeRollupPublicInputs const& left,
-                                                  BaseOrMergeRollupPublicInputs const& right);
-NT::fr assert_both_input_proofs_of_same_height_and_return(DummyComposer& composer,
-                                                          BaseOrMergeRollupPublicInputs const& left,
-                                                          BaseOrMergeRollupPublicInputs const& right);
-void assert_equal_constants(DummyComposer& composer,
-                            BaseOrMergeRollupPublicInputs const& left,
-                            BaseOrMergeRollupPublicInputs const& right);
-AggregationObject aggregate_proofs(BaseOrMergeRollupPublicInputs const& left,
-                                   BaseOrMergeRollupPublicInputs const& right);
 } // namespace aztec3::circuits::rollup::native_merge_rollup

--- a/cpp/src/aztec3/circuits/rollup/root/native_root_rollup_circuit.cpp
+++ b/cpp/src/aztec3/circuits/rollup/root/native_root_rollup_circuit.cpp
@@ -13,7 +13,7 @@
 #include <aztec3/circuits/abis/rollup/root/root_rollup_inputs.hpp>
 #include <aztec3/circuits/abis/rollup/root/root_rollup_public_inputs.hpp>
 #include <aztec3/circuits/abis/rollup/nullifier_leaf_preimage.hpp>
-#include <aztec3/circuits/rollup/merge/native_merge_rollup_circuit.hpp>
+#include <aztec3/circuits/rollup/components/components.hpp>
 #include <cstdint>
 #include <iostream>
 #include <tuple>
@@ -26,55 +26,7 @@ namespace aztec3::circuits::rollup::native_root_rollup {
 
 // Access Native types through NT namespace
 
-template <size_t N>
-NT::fr iterate_through_tree_via_sibling_path(NT::fr leaf,
-                                             NT::uint32 const& leafIndex,
-                                             std::array<NT::fr, N> const& siblingPath)
-{
-    for (size_t i = 0; i < siblingPath.size(); i++) {
-        if (leafIndex & (1 << i)) {
-            leaf = proof_system::plonk::stdlib::merkle_tree::hash_pair_native(siblingPath[i], leaf);
-        } else {
-            leaf = proof_system::plonk::stdlib::merkle_tree::hash_pair_native(leaf, siblingPath[i]);
-        }
-    }
-    return leaf;
-}
-
-template <size_t N>
-void check_membership(DummyComposer& composer,
-                      NT::fr const& leaf,
-                      NT::uint32 const& leafIndex,
-                      std::array<NT::fr, N> const& siblingPath,
-                      NT::fr const& root)
-{
-    auto computed_root = iterate_through_tree_via_sibling_path(leaf, leafIndex, siblingPath);
-    composer.do_assert(root == computed_root, "Membership check failed");
-}
-
-template <size_t N>
-AppendOnlySnapshot insert_at_empty_in_snapshot_tree(DummyComposer& composer,
-                                                    AppendOnlySnapshot const& old_snapshot,
-                                                    std::array<NT::fr, N> const& siblingPath,
-                                                    NT::fr leaf)
-{
-    // check that the value is zero at the path (unused)
-    // TODO: We should be able to actually skip this, because the contract will be indirectly enforce it through
-    // old_snapshot.next_available_leaf_index
-    check_membership(composer, fr::zero(), old_snapshot.next_available_leaf_index, siblingPath, old_snapshot.root);
-
-    // Compute the new root after the update
-    auto new_root = iterate_through_tree_via_sibling_path(leaf, old_snapshot.next_available_leaf_index, siblingPath);
-
-    return { .root = new_root, .next_available_leaf_index = old_snapshot.next_available_leaf_index + 1 };
-}
-
-// Important types:
-//   - BaseRollupPublicInputs - where we want to put our return values
-//
-// TODO: replace auto
-RootRollupPublicInputs root_rollup_circuit(aztec3::utils::DummyComposer& composer,
-                                           RootRollupInputs const& rootRollupInputs)
+RootRollupPublicInputs root_rollup_circuit(DummyComposer& composer, RootRollupInputs const& rootRollupInputs)
 {
     // TODO: Verify the previous rollup proofs
     // TODO: Check both previous rollup vks (in previous_rollup_data) against the permitted set of kernel vks.
@@ -83,25 +35,29 @@ RootRollupPublicInputs root_rollup_circuit(aztec3::utils::DummyComposer& compose
     auto left = rootRollupInputs.previous_rollup_data[0].base_or_merge_rollup_public_inputs;
     auto right = rootRollupInputs.previous_rollup_data[1].base_or_merge_rollup_public_inputs;
 
-    AggregationObject aggregation_object = native_merge_rollup::aggregate_proofs(left, right);
-    native_merge_rollup::assert_both_input_proofs_of_same_rollup_type(composer, left, right);
-    native_merge_rollup::assert_both_input_proofs_of_same_height_and_return(composer, left, right);
-    native_merge_rollup::assert_equal_constants(composer, left, right);
-    native_merge_rollup::assert_prev_rollups_follow_on_from_each_other(composer, left, right);
+    auto aggregation_object = components::aggregate_proofs(left, right);
+    components::assert_both_input_proofs_of_same_rollup_type(composer, left, right);
+    components::assert_both_input_proofs_of_same_height_and_return(composer, left, right);
+    components::assert_equal_constants(composer, left, right);
+    components::assert_prev_rollups_follow_on_from_each_other(composer, left, right);
 
     // Update the historic private data tree
-    AppendOnlySnapshot end_tree_of_historic_private_data_tree_roots_snapshot =
-        insert_at_empty_in_snapshot_tree(composer,
-                                         left.constants.start_tree_of_historic_private_data_tree_roots_snapshot,
-                                         rootRollupInputs.new_historic_private_data_tree_root_sibling_path,
-                                         right.end_private_data_tree_snapshot.root);
+    auto end_tree_of_historic_private_data_tree_roots_snapshot = components::insert_subtree_to_snapshot_tree(
+        composer,
+        left.constants.start_tree_of_historic_private_data_tree_roots_snapshot,
+        rootRollupInputs.new_historic_private_data_tree_root_sibling_path,
+        fr::zero(),
+        right.end_private_data_tree_snapshot.root,
+        0);
 
     // Update the historic private data tree
-    AppendOnlySnapshot end_tree_of_historic_contract_tree_roots_snapshot =
-        insert_at_empty_in_snapshot_tree(composer,
-                                         left.constants.start_tree_of_historic_contract_tree_roots_snapshot,
-                                         rootRollupInputs.new_historic_contract_tree_root_sibling_path,
-                                         right.end_contract_tree_snapshot.root);
+    auto end_tree_of_historic_contract_tree_roots_snapshot =
+        components::insert_subtree_to_snapshot_tree(composer,
+                                                    left.constants.start_tree_of_historic_contract_tree_roots_snapshot,
+                                                    rootRollupInputs.new_historic_contract_tree_root_sibling_path,
+                                                    fr::zero(),
+                                                    right.end_contract_tree_snapshot.root,
+                                                    0);
 
     RootRollupPublicInputs public_inputs = {
         .end_aggregation_object = aggregation_object,
@@ -117,7 +73,7 @@ RootRollupPublicInputs root_rollup_circuit(aztec3::utils::DummyComposer& compose
         .start_tree_of_historic_contract_tree_roots_snapshot =
             left.constants.start_tree_of_historic_contract_tree_roots_snapshot,
         .end_tree_of_historic_contract_tree_roots_snapshot = end_tree_of_historic_contract_tree_roots_snapshot,
-        .calldata_hash = native_merge_rollup::compute_calldata_hash(rootRollupInputs.previous_rollup_data),
+        .calldata_hash = components::compute_calldata_hash(rootRollupInputs.previous_rollup_data),
     };
 
     return public_inputs;


### PR DESCRIPTION
# Description

Moves components that are used in multiple rollup circuits into components such that they can be reused instead of duplicated. 

# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] There are no circuit changes, OR specifications in `/specs` have been updated.
- [ ] There are no circuit changes, OR a cryptographer has been assigned for review.
- [ ] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [ ] The branch has been rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
- [ ] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [ ] If existing code has been modified, such documentation has been added or updated.

> **Note**
> If you are updating the submodule, please make sure you do it in its own _special_ PR and avoid making changes to the submodule as a part of other PRs.
> To update a submodule, you can run the following commands:
> ```console
> $ git submodule update --recursive
> ```
> Alternatively, you can select a particular commit in `barretenberg/aztec3` that you wish to point to:
> ```console
> $ cd barretenberg
> $ git pull origin aztec3        # This will point to the latest commit in `barretenberg/aztec3`
> $ git checkout <commit_hash>    # Use this if you wish to point to a particular commit.
> $ cd ..
> $ git add . && git commit -m <commit_msg>
> $ git push
> ```
