### PR TITLE
fix: typos in description lines of the code 

### DIFF
--- a/cpp/src/aztec3/circuits/abis/public_circuit_public_inputs.hpp
+++ b/cpp/src/aztec3/circuits/abis/public_circuit_public_inputs.hpp
@@ -121,7 +121,7 @@ template <typename NCT> void read(uint8_t const*& it, PublicCircuitPublicInputs<
     read(it, pis.args);
     read(it, pis.return_values);
     read(it, pis.emitted_events);
-    read(it, pis.emitted_ouputs);
+    read(it, pis.emitted_outputs);
 
     read(it, pis.state_transitions);
     read(it, pis.state_reads);
@@ -144,7 +144,7 @@ void write(std::vector<uint8_t>& buf, PublicCircuitPublicInputs<NCT> const& priv
     write(buf, pis.args);
     write(buf, pis.return_values);
     write(buf, pis.emitted_events);
-    write(buf, pis.emitted_ouputs);
+    write(buf, pis.emitted_outputs);
 
     write(buf, pis.state_transitions);
     write(buf, pis.state_reads);


### PR DESCRIPTION
# Description

Fixed typos in description lines of the code [public_circuit_public_inputs.hpp](https://github.com/AztecProtocol/aztec3-circuits/commit/95e1337c5a354e4465edaab019fd61c848c5ab64)

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] There are no circuit changes, OR specifications in `/specs` have been updated.
- [x] There are no circuit changes, OR a cryptographer has been assigned for review.
- [ ] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
- [ ] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [ ] If existing code has been modified, such documentation has been added or updated.

> **Note**
> If you are updating the submodule, please make sure you do it in its own _special_ PR and avoid making changes to the submodule as a part of other PRs.
> To update a submodule, you can run the following commands:
> ```console
> $ git submodule update --recursive
> ```
> Alternatively, you can select a particular commit in `barretenberg/aztec3` that you wish to point to:
> ```console
> $ cd barretenberg
> $ git pull origin aztec3        # This will point to the latest commit in `barretenberg/aztec3`
> $ git checkout <commit_hash>    # Use this if you wish to point to a particular commit.
> $ cd ..
> $ git add . && git commit -m <commit_msg>
> $ git push
> ```
